### PR TITLE
feat(预览): 增加桌面和移动端预览模式切换功能

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-tabs": "^1.1.12",
     "@radix-ui/react-tooltip": "^1.2.7",
     "ahooks": "^3.9.0",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.12
+        version: 1.1.12(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-tooltip':
         specifier: ^1.2.7
         version: 1.2.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -772,6 +775,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.12':
+    resolution: {integrity: sha512-GTVAlRVrQrSw3cEARM0nAx73ixrWDPNZAruETn3oHCNP6SbZ/hNxdxp+u7VkIEv3/sFoLq1PfcHrl7Pnp0CDpw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-tooltip@1.2.7':
@@ -2717,6 +2733,22 @@ snapshots:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.8
+
+  '@radix-ui/react-tabs@1.1.12(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-roving-focus': 1.1.10(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
 
   '@radix-ui/react-tooltip@1.2.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,64 @@
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function TabsList({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/src/controllers/exchange-controller.ts
+++ b/src/controllers/exchange-controller.ts
@@ -9,12 +9,14 @@ import {
 } from '@/api/app'
 import i18n from '@/i18n'
 import { getStorage, setStorage } from '@/lib/storage'
-import { groupBy, isBoolean } from 'lodash'
+import { groupBy } from 'lodash'
 import { makeAutoObservable, runInAction } from 'mobx'
 import appListController from './app-list-controller'
 
 export const STATUSES_RUNNING = ['PLANNING', 'GENERATING']
 export const STATUSES_FINISHED = ['SUCCESSFUL', 'FAILED']
+
+const VALID_PREVIEW_MODES: PreviewMode[] = ['desktop', 'mobile', 'disabled']
 
 class ExchangeController {
   isGenerating = false
@@ -22,21 +24,23 @@ class ExchangeController {
   exchangeHistories: Exchange[] = []
   activeExchange: Nullable<Exchange> = null
 
-  previewEnabled = true
+  previewMode: PreviewMode = 'desktop'
   productUrl = ''
   managementUrl = ''
 
   abortController: Nullable<AbortController> = null
 
   constructor() {
-    const previewEnabled = getStorage('kiwi:ui:preview-enabled')
-    this.previewEnabled = isBoolean(previewEnabled) ? previewEnabled : true
+    const previewMode = getStorage('kiwi:ui:preview-mode')
+    if (previewMode && VALID_PREVIEW_MODES.includes(previewMode)) {
+      this.previewMode = previewMode
+    }
     makeAutoObservable(this)
   }
 
-  togglePreviewEnabled() {
-    this.previewEnabled = !this.previewEnabled
-    setStorage('kiwi:ui:preview-enabled', this.previewEnabled)
+  updatePreviewMode(mode: PreviewMode) {
+    this.previewMode = mode
+    setStorage('kiwi:ui:preview-mode', mode)
   }
 
   async sendMessageToAI(prompt: string) {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -3,7 +3,7 @@ import { isString, isUndefined } from 'lodash'
 export type StorageKey = {
   'kiwi:ui:theme': Theme
   'kiwi:ui:beta-tip-shown': boolean
-  'kiwi:ui:preview-enabled': boolean
+  'kiwi:ui:preview-mode': PreviewMode
 }
 
 export type StorageKeyType = keyof StorageKey

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -45,7 +45,9 @@
   },
   "navbar": {
     "deleteApp": "Delete Application",
-    "togglePreview": "Toggle Preview",
+    "previewAsDesktop": "Desktop Mode",
+    "previewAsMobile": "Mobile Mode",
+    "disabledPreview": "Disable Preview",
     "visitApp": "Visit Application",
     "visitManagement": "Visit Management",
     "visitWebsites": "Visit Websites"

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -45,7 +45,9 @@
   },
   "navbar": {
     "deleteApp": "删除应用",
-    "togglePreview": "显示/隐藏预览",
+    "previewAsDesktop": "桌面模式",
+    "previewAsMobile": "移动模式",
+    "disabledPreview": "禁用预览",
     "visitApp": "访问应用",
     "visitManagement": "访问管理后台",
     "visitWebsites": "访问应用站点"

--- a/src/pages/index/[appId]/index.tsx
+++ b/src/pages/index/[appId]/index.tsx
@@ -1,7 +1,7 @@
 import { KiwiLogo } from '@/components/kiwi-logo'
 import appListController from '@/controllers/app-list-controller'
 import exchangeController from '@/controllers/exchange-controller'
-import { nextTick } from '@/lib/utils'
+import { cn, nextTick } from '@/lib/utils'
 import { useCreation, useRequest, useUnmount } from 'ahooks'
 import { reaction } from 'mobx'
 import { observer } from 'mobx-react-lite'
@@ -45,8 +45,13 @@ const ChatView = observer(() => {
 
   return appListController.selectedApp ? (
     <div className="h-0 flex-1 flex">
-      {exchangeController.previewEnabled && (
-        <AppPreview className="h-full flex-2/3 border-r shadow" />
+      {exchangeController.previewMode !== 'disabled' && (
+        <AppPreview
+          className={cn(
+            'h-full border-r shadow flex-2/3',
+            exchangeController.previewMode === 'mobile' && 'max-w-[414px]'
+          )}
+        />
       )}
 
       <section className="h-full flex-1/3 flex flex-col min-w-[375px]">

--- a/src/pages/index/components/delete-app-button.tsx
+++ b/src/pages/index/components/delete-app-button.tsx
@@ -61,7 +61,7 @@ export const DeleteAppButton = observer(() => {
           <TooltipTrigger asChild>
             <Button
               variant="ghost"
-              size="icon-sm"
+              size="icon"
               className="!text-red-500 hover:bg-red-500/10"
               onClick={showDeleteDialog}
             >

--- a/src/pages/index/components/nav-header.tsx
+++ b/src/pages/index/components/nav-header.tsx
@@ -1,20 +1,12 @@
-import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import { SidebarTrigger } from '@/components/ui/sidebar'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
 import appListController from '@/controllers/app-list-controller'
 import exchangeController from '@/controllers/exchange-controller'
-import { useIsMobile } from '@/hooks/use-mobile'
 import { cn } from '@/lib/utils'
-import { Eye, EyeOff } from 'lucide-react'
 import { observer } from 'mobx-react-lite'
-import { useTranslation } from 'react-i18next'
 import { DeleteAppButton } from './delete-app-button'
 import { OpenWebsitesButton } from './open-websites-button'
+import { PreviewModeButtons } from './preview-mode-buttons'
 
 type AppProps = {
   app: Nullable<Application>
@@ -34,30 +26,6 @@ const AppName = ({ app }: AppProps) => {
   )
 }
 
-const TogglePreviewButton = observer(({ app }: AppProps) => {
-  const { t } = useTranslation()
-  const isMobile = useIsMobile()
-  if (isMobile || !app || !exchangeController.productUrl) return null
-
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          className="hover:bg-foreground/5"
-          onClick={() => exchangeController.togglePreviewEnabled()}
-        >
-          {exchangeController.previewEnabled ? <Eye /> : <EyeOff />}
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent>
-        <p>{t('navbar.togglePreview')}</p>
-      </TooltipContent>
-    </Tooltip>
-  )
-})
-
 export const NavHeader = observer(() => {
   const selectedApp = appListController.selectedApp
 
@@ -65,7 +33,7 @@ export const NavHeader = observer(() => {
     <>
       <header
         className={cn(
-          'h-14 px-4 flex justify-between items-center',
+          'h-14 px-4 flex justify-between items-center bg-background',
           selectedApp && 'border-b'
         )}
       >
@@ -74,8 +42,8 @@ export const NavHeader = observer(() => {
           <AppName app={selectedApp} />
         </div>
 
-        <div className="flex gap-1">
-          <TogglePreviewButton app={selectedApp} />
+        <div className="flex items-center gap-1">
+          <PreviewModeButtons />
           <OpenWebsitesButton
             productUrl={exchangeController.productUrl}
             managementUrl={exchangeController.managementUrl}

--- a/src/pages/index/components/open-websites-button.tsx
+++ b/src/pages/index/components/open-websites-button.tsx
@@ -31,7 +31,7 @@ export const OpenWebsitesButton = memo(
       <DropdownMenuTrigger asChild>
         <Button
           variant={small ? 'secondary' : 'ghost'}
-          size={small ? 'icon-xs' : 'icon-sm'}
+          size={small ? 'icon-xs' : 'icon'}
           className="hover:bg-foreground/5"
         >
           <AppWindow />

--- a/src/pages/index/components/preview-mode-buttons.tsx
+++ b/src/pages/index/components/preview-mode-buttons.tsx
@@ -1,0 +1,64 @@
+import { Separator } from '@/components/ui/separator'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import appListController from '@/controllers/app-list-controller'
+import exchangeController from '@/controllers/exchange-controller'
+import { useIsMobile } from '@/hooks/use-mobile'
+import { useMemoizedFn } from 'ahooks'
+import { EyeOff, Monitor, Smartphone } from 'lucide-react'
+import { observer } from 'mobx-react-lite'
+import { useTranslation } from 'react-i18next'
+
+export const PreviewModeButtons = observer(() => {
+  const { t } = useTranslation()
+  const isMobile = useIsMobile()
+  const app = appListController.selectedApp
+  const handleModeChange = useMemoizedFn((value: string) => {
+    exchangeController.previewMode = value as PreviewMode
+  })
+  if (isMobile || !app || !exchangeController.productUrl) return null
+
+  return (
+    <>
+      <Tabs
+        value={exchangeController.previewMode}
+        onValueChange={handleModeChange}
+      >
+        <TabsList>
+          <Tooltip>
+            <TooltipTrigger>
+              <TabsTrigger value="desktop">
+                <Monitor />
+              </TabsTrigger>
+            </TooltipTrigger>
+            <TooltipContent>{t('navbar.previewAsDesktop')}</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger>
+              <TabsTrigger value="mobile">
+                <Smartphone />
+              </TabsTrigger>
+            </TooltipTrigger>
+            <TooltipContent>{t('navbar.previewAsMobile')}</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger>
+              <TabsTrigger value="disabled">
+                <EyeOff />
+              </TabsTrigger>
+            </TooltipTrigger>
+            <TooltipContent>{t('navbar.disabledPreview')}</TooltipContent>
+          </Tooltip>
+        </TabsList>
+      </Tabs>
+      <Separator
+        orientation="vertical"
+        className="ml-1.5 data-[orientation=vertical]:h-4"
+      />
+    </>
+  )
+})

--- a/src/typedef.d.ts
+++ b/src/typedef.d.ts
@@ -50,3 +50,5 @@ interface Exchange {
   productURL: string | null
   managementURL: string | null
 }
+
+type PreviewMode = 'desktop' | 'mobile' | 'disabled'


### PR DESCRIPTION
添加新的预览模式选项，支持在桌面、移动端和禁用预览之间切换
重构预览相关代码，使用新的 PreviewMode 类型
更新相关翻译文案和 UI 组件
添加 @radix-ui/react-tabs 依赖用于模式切换 UI