### PR TITLE
feat(ui): 添加Popover组件并替换DropdownMenu和Dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-hover-card": "^1.1.14",
     "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-popover": "^1.1.14",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@radix-ui/react-label':
         specifier: ^2.1.7
         version: 2.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-popover':
+        specifier: ^1.1.14
+        version: 1.1.14(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-select':
         specifier: ^2.2.5
         version: 2.2.5(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -666,6 +669,19 @@ packages:
 
   '@radix-ui/react-menu@2.1.15':
     resolution: {integrity: sha512-tVlmA3Vb9n8SZSd+YSbuFR66l87Wiy4du+YE+0hzKQEANA+7cWKH1WgqcEX4pXqxUFQKrWQGHdvEfw00TjFiew==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.14':
+    resolution: {integrity: sha512-ODz16+1iIbGUfFEfKx2HTPKizg2MN39uIOV8MXeHnmdd3i/N9Wt7vU46wbHsqA0xoaQyXVcs0KIlBdOA2Y95bw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2617,6 +2633,29 @@ snapshots:
       '@radix-ui/react-roving-focus': 1.1.10(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.1.8)(react@19.1.0)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      aria-hidden: 1.2.6
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-remove-scroll: 2.7.1(@types/react@19.1.8)(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@radix-ui/react-popover@1.1.14(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-focus-guards': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-popper': 1.2.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.1.0)
       aria-hidden: 1.2.6
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,46 @@
+import * as React from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }

--- a/src/pages/index/components/delete-app-button.tsx
+++ b/src/pages/index/components/delete-app-button.tsx
@@ -1,20 +1,15 @@
 import { Spinner } from '@/components/spinner'
 import { Button } from '@/components/ui/button'
 import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import appListController from '@/controllers/app-list-controller'
 import { useSelectApp } from '@/hooks/use-select-app'
-import { useBoolean, useRequest } from 'ahooks'
+import { Tooltip } from '@radix-ui/react-tooltip'
+import { useRequest } from 'ahooks'
 import { Trash2 } from 'lucide-react'
 import { observer } from 'mobx-react-lite'
 import { useTranslation } from 'react-i18next'
@@ -23,14 +18,6 @@ import { toast } from 'sonner'
 export const DeleteAppButton = observer(() => {
   {
     const { t } = useTranslation()
-    const [
-      deleteDialogStatus,
-      {
-        setTrue: showDeleteDialog,
-        setFalse: hideDeleteDialog,
-        set: setDeleteDialogStatus,
-      },
-    ] = useBoolean(false)
     const handleSelectApp = useSelectApp()
 
     const { loading: deleteLoading, run: handleComfirmDelete } = useRequest(
@@ -44,8 +31,6 @@ export const DeleteAppButton = observer(() => {
         } catch (error) {
           console.error('Failed to delete application:', error)
           toast.error(`Error: ${(error as Error).message}`)
-        } finally {
-          setDeleteDialogStatus(false)
         }
       },
       {
@@ -56,53 +41,48 @@ export const DeleteAppButton = observer(() => {
     if (!appListController.selectedApp) return null
 
     return (
-      <>
+      <Popover>
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="!text-red-500 hover:bg-red-500/10"
-              onClick={showDeleteDialog}
-            >
-              <Trash2 />
-            </Button>
+            <PopoverTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="!text-red-500 hover:bg-red-500/10"
+              >
+                <Trash2 />
+              </Button>
+            </PopoverTrigger>
           </TooltipTrigger>
           <TooltipContent>
             <p>{t('navbar.deleteApp')}</p>
           </TooltipContent>
         </Tooltip>
 
-        <Dialog open={deleteDialogStatus} onOpenChange={setDeleteDialogStatus}>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>
-                {t('sidebar.deleteTitle', {
-                  appName: appListController.selectedApp.name,
-                })}
-              </DialogTitle>
-            </DialogHeader>
-
-            <p>
-              {t('sidebar.deleteConfirmMessage', {
-                appName: appListController.selectedApp.name,
-              })}
-            </p>
-
-            <DialogFooter>
-              <Button onClick={hideDeleteDialog}>{t('common.cancel')}</Button>
-              <Button
-                variant="destructive"
-                onClick={handleComfirmDelete}
-                disabled={deleteLoading}
-              >
-                {deleteLoading && <Spinner />}
-                {t('sidebar.delete')}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-      </>
+        <PopoverContent className="w-[320px]" align="end">
+          <p className="text-lg font-bold">
+            {t('sidebar.deleteTitle', {
+              appName: appListController.selectedApp.name,
+            })}
+          </p>
+          <p className="my-2">
+            {t('sidebar.deleteConfirmMessage', {
+              appName: appListController.selectedApp.name,
+            })}
+          </p>
+          <div className="flex justify-end gap-2">
+            <Button
+              size="sm"
+              variant="destructive"
+              onClick={handleComfirmDelete}
+              disabled={deleteLoading}
+            >
+              {deleteLoading && <Spinner />}
+              {t('common.delete')}
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
     )
   }
 })

--- a/src/pages/index/components/logout-button.tsx
+++ b/src/pages/index/components/logout-button.tsx
@@ -1,11 +1,9 @@
 import { Button } from '@/components/ui/button'
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
 import authController from '@/controllers/auth-controller'
 import { LogOut } from 'lucide-react'
 import { memo } from 'react'
@@ -15,8 +13,8 @@ export const LogoutButton = memo(() => {
   const { t } = useTranslation()
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
+    <Popover>
+      <PopoverTrigger asChild>
         <Button
           className="!border-border/80 shadow-md"
           variant="outline"
@@ -25,18 +23,18 @@ export const LogoutButton = memo(() => {
         >
           <LogOut />
         </Button>
-      </DropdownMenuTrigger>
+      </PopoverTrigger>
 
-      <DropdownMenuContent align="end">
-        <DropdownMenuGroup>
-          <DropdownMenuItem
-            className="!text-destructive"
-            onClick={() => authController.logout()}
-          >
-            {t('sidebar.logoutTitle')}
-          </DropdownMenuItem>
-        </DropdownMenuGroup>
-      </DropdownMenuContent>
-    </DropdownMenu>
+      <PopoverContent align="end" className="w-auto p-1">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="!text-destructive"
+          onClick={() => authController.logout()}
+        >
+          {t('sidebar.logoutTitle')}
+        </Button>
+      </PopoverContent>
+    </Popover>
   )
 })


### PR DESCRIPTION
添加@radix-ui/react-popover依赖
实现Popover组件及其子组件
将LogoutButton和DeleteAppButton中的DropdownMenu和Dialog替换为Popover