### PR TITLE
feat(预览): 合并预览模式选项并添加重置功能

### DIFF
--- a/src/controllers/app-list-controller.ts
+++ b/src/controllers/app-list-controller.ts
@@ -60,6 +60,11 @@ class AppListController {
       () => (this.appList = this.appList.filter(app => app.id !== appId))
     )
   }
+  reset() {
+    this.initialized = false
+    this.appList = []
+    this.selectedApp = null
+  }
 }
 
 export default new AppListController()

--- a/src/controllers/exchange-controller.ts
+++ b/src/controllers/exchange-controller.ts
@@ -15,6 +15,7 @@ import appListController from './app-list-controller'
 
 export const STATUSES_RUNNING = ['PLANNING', 'GENERATING']
 export const STATUSES_FINISHED = ['SUCCESSFUL', 'FAILED']
+export const STATUSES_CANCELLED = ['CANCELLED', 'REVERTED']
 
 const VALID_PREVIEW_MODES: PreviewMode[] = ['desktop', 'mobile', 'disabled']
 
@@ -215,9 +216,8 @@ class ExchangeController {
     runInAction(() => (this.activeExchange = finalExchangeData))
 
     if (
-      finalExchangeData.status === 'SUCCESSFUL' ||
-      finalExchangeData.status === 'FAILED' ||
-      finalExchangeData.status === 'CANCELLED'
+      STATUSES_FINISHED.includes(finalExchangeData.status) ||
+      STATUSES_CANCELLED.includes(finalExchangeData.status)
     ) {
       this.terminateSseMessage(finalExchangeData)
     }
@@ -252,6 +252,16 @@ class ExchangeController {
     this.isGenerating = false
     this.abortController?.abort()
     this.abortController = null
+  }
+
+  reset() {
+    this.activeExchange = null
+    this.isGenerating = false
+    this.abortController?.abort()
+    this.abortController = null
+    this.exchangeHistories = []
+    this.productUrl = ''
+    this.managementUrl = ''
   }
 
   private updatePreviewUrl() {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -45,9 +45,7 @@
   },
   "navbar": {
     "deleteApp": "Delete Application",
-    "previewAsDesktop": "Desktop Mode",
-    "previewAsMobile": "Mobile Mode",
-    "disabledPreview": "Disable Preview",
+    "previewMode": "Preview Mode",
     "visitApp": "Visit Application",
     "visitManagement": "Visit Management",
     "visitWebsites": "Visit Websites"

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -45,9 +45,7 @@
   },
   "navbar": {
     "deleteApp": "删除应用",
-    "previewAsDesktop": "桌面模式",
-    "previewAsMobile": "移动模式",
-    "disabledPreview": "禁用预览",
+    "previewMode": "预览模式",
     "visitApp": "访问应用",
     "visitManagement": "访问管理后台",
     "visitWebsites": "访问应用站点"

--- a/src/pages/index/[appId]/index.tsx
+++ b/src/pages/index/[appId]/index.tsx
@@ -1,11 +1,10 @@
 import { KiwiLogo } from '@/components/kiwi-logo'
 import appListController from '@/controllers/app-list-controller'
 import exchangeController from '@/controllers/exchange-controller'
-import { cn, nextTick } from '@/lib/utils'
-import { useCreation, useRequest, useUnmount } from 'ahooks'
-import { reaction } from 'mobx'
+import { cn } from '@/lib/utils'
+import { useRequest, useUnmount } from 'ahooks'
 import { observer } from 'mobx-react-lite'
-import { useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Loading } from '../../../components/loading'
 import { AppPreview } from './components/app-preview'
@@ -23,24 +22,12 @@ const ChatView = observer(() => {
     }
   )
 
-  const disposeReaction = useCreation(
-    () =>
-      reaction(
-        () => [
-          exchangeController.exchangeHistories,
-          exchangeController.activeExchange,
-        ],
-        async () => {
-          await nextTick()
-          messagesEndRef.current?.scrollIntoView({ behavior: 'instant' })
-        }
-      ),
-    []
-  )
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'instant' })
+  }, [historyLoading])
 
   useUnmount(() => {
     exchangeController.terminateSseMessage()
-    disposeReaction()
   })
 
   return appListController.selectedApp ? (

--- a/src/pages/index/components/logout-button.tsx
+++ b/src/pages/index/components/logout-button.tsx
@@ -4,7 +4,9 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover'
+import appListController from '@/controllers/app-list-controller'
 import authController from '@/controllers/auth-controller'
+import exchangeController from '@/controllers/exchange-controller'
 import { LogOut } from 'lucide-react'
 import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -30,7 +32,11 @@ export const LogoutButton = memo(() => {
           variant="ghost"
           size="sm"
           className="!text-destructive"
-          onClick={() => authController.logout()}
+          onClick={() => {
+            authController.logout()
+            appListController.reset()
+            exchangeController.reset()
+          }}
         >
           {t('sidebar.logoutTitle')}
         </Button>

--- a/src/pages/index/components/nav-header.tsx
+++ b/src/pages/index/components/nav-header.tsx
@@ -33,8 +33,8 @@ export const NavHeader = observer(() => {
     <>
       <header
         className={cn(
-          'h-14 px-4 flex justify-between items-center bg-background',
-          selectedApp && 'border-b'
+          'h-14 px-4 flex justify-between items-center',
+          selectedApp && 'border-b bg-background'
         )}
       >
         <div className="flex items-center gap-2">

--- a/src/pages/index/components/preview-mode-buttons.tsx
+++ b/src/pages/index/components/preview-mode-buttons.tsx
@@ -1,20 +1,13 @@
 import { Separator } from '@/components/ui/separator'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
 import appListController from '@/controllers/app-list-controller'
 import exchangeController from '@/controllers/exchange-controller'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { useMemoizedFn } from 'ahooks'
 import { EyeOff, Monitor, Smartphone } from 'lucide-react'
 import { observer } from 'mobx-react-lite'
-import { useTranslation } from 'react-i18next'
 
 export const PreviewModeButtons = observer(() => {
-  const { t } = useTranslation()
   const isMobile = useIsMobile()
   const app = appListController.selectedApp
   const handleModeChange = useMemoizedFn((value: string) => {
@@ -29,30 +22,17 @@ export const PreviewModeButtons = observer(() => {
         onValueChange={handleModeChange}
       >
         <TabsList>
-          <Tooltip>
-            <TooltipTrigger>
-              <TabsTrigger value="desktop">
-                <Monitor />
-              </TabsTrigger>
-            </TooltipTrigger>
-            <TooltipContent>{t('navbar.previewAsDesktop')}</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger>
-              <TabsTrigger value="mobile">
-                <Smartphone />
-              </TabsTrigger>
-            </TooltipTrigger>
-            <TooltipContent>{t('navbar.previewAsMobile')}</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger>
-              <TabsTrigger value="disabled">
-                <EyeOff />
-              </TabsTrigger>
-            </TooltipTrigger>
-            <TooltipContent>{t('navbar.disabledPreview')}</TooltipContent>
-          </Tooltip>
+          <TabsTrigger value="desktop">
+            <Monitor />
+          </TabsTrigger>
+
+          <TabsTrigger value="mobile">
+            <Smartphone />
+          </TabsTrigger>
+
+          <TabsTrigger value="disabled">
+            <EyeOff />
+          </TabsTrigger>
         </TabsList>
       </Tabs>
       <Separator


### PR DESCRIPTION
重构预览模式按钮，将桌面、移动和禁用预览合并为单一选项
为应用列表和交换控制器添加重置方法，在登出时清理状态
优化聊天视图的滚动行为，移除不必要的反应式监听